### PR TITLE
Ensure temp file cleanup in Invoke-AdbCommand

### DIFF
--- a/adb-file-manager.ps1
+++ b/adb-file-manager.ps1
@@ -67,13 +67,17 @@ function Invoke-AdbCommand {
     )
     Write-Log "Executing ADB Command: adb $Command" "DEBUG"
 
-    # Using temporary files for stdout/stderr is more robust for capturing all output
-    $process = Start-Process adb -ArgumentList $Command -Wait -NoNewWindow -PassThru -RedirectStandardOutput "temp_stdout.txt" -RedirectStandardError "temp_stderr.txt"
-    $exitCode = $process.ExitCode
-    
-    $stdout = Get-Content "temp_stdout.txt" -Raw -Encoding UTF8 -ErrorAction SilentlyContinue
-    $stderr = Get-Content "temp_stderr.txt" -Raw -Encoding UTF8 -ErrorAction SilentlyContinue
-    Remove-Item "temp_stdout.txt", "temp_stderr.txt" -ErrorAction SilentlyContinue
+    try {
+        # Using temporary files for stdout/stderr is more robust for capturing all output
+        $process = Start-Process adb -ArgumentList $Command -Wait -NoNewWindow -PassThru -RedirectStandardOutput "temp_stdout.txt" -RedirectStandardError "temp_stderr.txt"
+        $exitCode = $process.ExitCode
+
+        $stdout = Get-Content "temp_stdout.txt" -Raw -Encoding UTF8 -ErrorAction SilentlyContinue
+        $stderr = Get-Content "temp_stderr.txt" -Raw -Encoding UTF8 -ErrorAction SilentlyContinue
+    }
+    finally {
+        Remove-Item "temp_stdout.txt", "temp_stderr.txt" -ErrorAction SilentlyContinue
+    }
 
     $success = ($exitCode -eq 0)
     # Some successful commands (like pull) write to stderr, so we combine them on success.


### PR DESCRIPTION
## Summary
- wrap Start-Process and temporary file reads in a try block
- move Remove-Item calls into finally block for guaranteed cleanup

## Testing
- `pwsh -NoLogo -NoProfile -Command "Get-Command ./adb-file-manager.ps1"`


------
https://chatgpt.com/codex/tasks/task_b_6897bcb9562c8331a925732c49001b1c