### PR TITLE
Clear directory cache when device disconnects

### DIFF
--- a/adb-file-manager.ps1
+++ b/adb-file-manager.ps1
@@ -93,7 +93,10 @@ function Invoke-AdbCommand {
             $script:DeviceStatus.DeviceName   = "No Device"
             $script:DeviceStatus.SerialNumber = ""
             # By resetting the timestamp, we force Update-DeviceStatus to do a full check next time it's called.
-            $script:LastStatusUpdateTime = [DateTime]::MinValue 
+            $script:LastStatusUpdateTime = [DateTime]::MinValue
+            # Purge any cached directory entries since they're now invalid without a device.
+            $script:DirectoryCache.Clear()
+            Write-Log "Directory cache cleared due to device loss." "WARN"
         }
     }
 


### PR DESCRIPTION
## Summary
- Clear cached directories upon device disconnection
- Log cache purge after device loss

## Testing
- `pwsh -NoLogo -NoProfile` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_b_68983c99dc6083318f01b00bc2b5375e