### PR TITLE
Warn on directory size calculation failures

### DIFF
--- a/adb-file-manager.ps1
+++ b/adb-file-manager.ps1
@@ -306,6 +306,7 @@ function Get-AndroidItemsSize {
     $totalSize = 0L
     $itemSizes = @{}
     $dirsToQuery = @()
+    $failedSizeCalc = $false
 
     # Separate files and directories. Files already have their size from the 'ls' command.
     foreach ($item in $Items) {
@@ -353,7 +354,12 @@ function Get-AndroidItemsSize {
         if (-not $itemSizes.ContainsKey($item.FullPath)) {
             $itemSizes[$item.FullPath] = 0L
             Write-Log "Could not determine size for '$($item.FullPath)'. Defaulting to 0." "WARN"
+            if ($item.Type -eq 'Directory') { $failedSizeCalc = $true }
         }
+    }
+
+    if ($failedSizeCalc) {
+        Write-Host "⚠️  Warning: Unable to determine size for one or more directories. They have been set to 0." -ForegroundColor Yellow
     }
 
     return [PSCustomObject]@{ TotalSize = $totalSize; ItemSizes = $itemSizes }


### PR DESCRIPTION
## Summary
- Track when directory sizes default to zero
- Inform the user when size determination fails

## Testing
- `pwsh -NoLogo -NoProfile -Command "Get-Command -Name ./adb-file-manager.ps1"`
- `pwsh -NoLogo -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseFile('./adb-file-manager.ps1',[ref]\$null,[ref]\$null) | Out-Null"`


------
https://chatgpt.com/codex/tasks/task_b_68990638abf483319b6d0376c85394d9