### PR TITLE
Add log levels and path sanitization to logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ It's faster, smarter, and provides far more feedback than standard ADB commands.
 * **✨ User-Friendly Interface**:
     * **GUI Pickers**: Uses the familiar Windows dialogs for selecting local files and folders to push or as a destination for pulls.
     * **Clean UI**: A polished and clean header shows the connected device status at all times.
-    * **Detailed Logging**: All major operations are logged to a timestamped file for easy debugging.
+* **Detailed Logging**: All major operations are logged to a timestamped file for easy debugging. Supports log levels (`INFO`, `DEBUG`, `ERROR`) with optional path sanitization.
 
 ## Prerequisites
 
@@ -52,6 +52,8 @@ It's faster, smarter, and provides far more feedback than standard ADB commands.
     * Navigate to the directory where you saved the script and run it:
         ```powershell
         .\adb-file-manager.ps1
+
+    * To include debug-level output, run the script with the `-LogLevel DEBUG` parameter.
         ```
 4.  **Use the Menu**: The script will guide you through the available options. The most powerful features are in the **Browse Device Filesystem** menu.
 


### PR DESCRIPTION
## Summary
- add configurable log level parameter and filtering
- support optional path sanitization within Write-Log
- document debug logging usage

## Testing
- ❌ `pwsh -NoProfile -Command "[ScriptBlock]::Create((Get-Content -Raw ./adb-file-manager.ps1)) | Out-Null"` *(pwsh not installed)*


------
https://chatgpt.com/codex/tasks/task_b_689da2651f7c8331b63dc89b4ac8db6b