### PR TITLE
Fix directory size command aggregation

### DIFF
--- a/adb-file-manager.ps1
+++ b/adb-file-manager.ps1
@@ -516,7 +516,7 @@ function Get-AndroidItemsSize {
 
     # If there are directories, query their sizes in one single, efficient command.
     if ($dirsToQuery.Count -gt 0) {
-        $sizeResult = Invoke-AdbCommand -State $State -Arguments @('shell','du','-sb') + $dirsToQuery
+        $sizeResult = Invoke-AdbCommand -State $State -Arguments (@('shell','du','-sb') + $dirsToQuery)
         $State = $sizeResult.State
         if ($sizeResult.Success -and $sizeResult.Output) {
             # The output lines look like: 5120	/sdcard/Download


### PR DESCRIPTION
## Summary
- Fix directory size calculation by grouping du arguments into a single array before invoking ADB

## Testing
- `/tmp/pwsh/pwsh -NoLogo -NoProfile -File /tmp/test.ps1`


------
https://chatgpt.com/codex/tasks/task_b_689dc6f1055883319a72495dd028c4e9