### PR TITLE
Handle directory listing failures with state object

### DIFF
--- a/adb-file-manager.ps1
+++ b/adb-file-manager.ps1
@@ -641,7 +641,7 @@ function Get-AndroidDirectoryContents {
     if (-not $result.Success) {
         Write-Host ""
         Write-ErrorMessage -Operation "Failed to list directory" -Item $Path -Details $result.Output
-        return @()
+        return [PSCustomObject]@{ State = $State; Items = @() }
     }
 
     $items = @()


### PR DESCRIPTION
## Summary
- Return a PSCustomObject with `State` and empty `Items` when `Get-AndroidDirectoryContents` fails to list a directory.
- Confirm callers (`Select-PullItems` and `Browse-AndroidFileSystem`) access `.State` and `.Items` from the returned object.

## Testing
- ❌ `pwsh` (PowerShell) not available; `apt-get install -y powershell` could not locate the package.


------
https://chatgpt.com/codex/tasks/task_b_689dc8432ac083319ade4b285b5c2351