### PR TITLE
Use Test-Path for destination folder validation

### DIFF
--- a/adb-file-manager.ps1
+++ b/adb-file-manager.ps1
@@ -726,7 +726,7 @@ function Select-PullItems {
 
     $destinationFolder = Show-FolderPicker "Select destination folder on PC"
     if (-not $destinationFolder) { Write-Host "🟡 Action cancelled." -ForegroundColor Yellow; return $null }
-    if (-not (Test-AndroidPath $destinationFolder)) { Write-ErrorMessage -Operation "Invalid path"; return $null }
+    if (-not (Test-Path -LiteralPath $destinationFolder)) { Write-ErrorMessage -Operation "Invalid path"; return $null }
 
     return [PSCustomObject]@{
         State       = $State


### PR DESCRIPTION
## Summary
- validate destination folders with `Test-Path -LiteralPath`

## Testing
- `pwsh -NoLogo -NoProfile -File /tmp/parse.ps1` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_b_689dcd1323d483319c124b5249885c5b