### PR TITLE
Use loop with bounds checking for path sanitization

### DIFF
--- a/adb-file-manager.ps1
+++ b/adb-file-manager.ps1
@@ -97,9 +97,9 @@ function Write-Log {
             param($m)
             $path = $m.Value
             $sep = $path.Contains('/') ? '/' : '\\'
-            $parts = $path -split '[\\/]+'
-            if ($parts.Length -gt 2) {
-                $parts[1..($parts.Length-2)] = '***'
+            [string[]]$parts = $path -split '[\\/]+'
+            for ($i = 1; $i -lt $parts.Length - 1; $i++) {
+                $parts[$i] = '***'
             }
             return ($parts -join $sep)
         })


### PR DESCRIPTION
## Summary
- Ensure path segments are stored as a string array before masking
- Replace range-based masking with bounds-checked loop for safety
- Rebuild sanitized path from updated parts

## Testing
- `pwsh -NoLogo -NoProfile -Command "Write-Host 'hello'"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_b_689dfe006ce08331a1806e350085096c