### PR TITLE
Resolve symlink targets in ls parser

### DIFF
--- a/adb-file-manager.ps1
+++ b/adb-file-manager.ps1
@@ -764,7 +764,17 @@ function Get-AndroidDirectoryContents {
                 $type = switch ($typeChar) {
                     'd' { 'Directory' }
                     '-' { 'File' }
-                    'l' { 'Link' }
+                    'l' {
+                        $linkType = 'Link'
+                        $target = Invoke-AdbCommand -State $State -Arguments @('shell','readlink','-f', "'$statPath'")
+                        $State = $target.State
+                        if ($target.Success -and $target.Output) {
+                            $targetLs = Invoke-AdbCommand -State $State -Arguments @('shell','ls','-ld', "'$($target.Output.Trim())'")
+                            $State = $targetLs.State
+                            if ($targetLs.Success -and $targetLs.Output.StartsWith('d')) { $linkType = 'Directory' }
+                        }
+                        $linkType
+                    }
                     default { 'Other' }
                 }
             }


### PR DESCRIPTION
## Summary
- resolve symlink targets when parsing `ls -ld` output on devices without `stat -c`

## Testing
- `adb version`
- `strings /tmp/run.log | tail -n 20` *(fails: no device connected)*

------
https://chatgpt.com/codex/tasks/task_b_689e08d7d27c8331a2b3256d303ef2c6