### PR TITLE
Replace ternary separator selection with if/else

### DIFF
--- a/adb-file-manager.ps1
+++ b/adb-file-manager.ps1
@@ -99,7 +99,11 @@ function Write-Log {
         $Message = [regex]::Replace($Message, '((?:[A-Za-z]:)?[\\/][^\s"'']*)', {
             param($m)
             $path = $m.Value
-            $sep = $path.Contains('/') ? '/' : '\\'
+            if ($path.Contains('/')) {
+                $sep = '/'
+            } else {
+                $sep = '\\'
+            }
             [string[]]$parts = $path -split '[\\/]+'
             for ($i = 1; $i -lt $parts.Length - 1; $i++) {
                 $parts[$i] = '***'


### PR DESCRIPTION
## Summary
- simplify path separator detection using explicit if/else block
- ensure Windows separator uses double backslash for sanitized paths

## Testing
- `pwsh -NoLogo -File adb-file-manager.ps1 -LogLevel INFO` *(fails: command not found: pwsh)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_b_689e1b3cac908331999e0b3d204054cb