### PR TITLE
Detect PowerShell version for ADB commands

### DIFF
--- a/adb-file-manager.ps1
+++ b/adb-file-manager.ps1
@@ -159,7 +159,13 @@ function Invoke-AdbCommand {
         $psi.RedirectStandardOutput = $true
         $psi.RedirectStandardError = $true
         $psi.UseShellExecute = $false
-        foreach ($arg in $argList) { $null = $psi.ArgumentList.Add($arg) }
+        if ($PSVersionTable.PSVersion.Major -ge 6) {
+            foreach ($arg in $argList) { $null = $psi.ArgumentList.Add($arg) }
+        }
+        else {
+            # PowerShell 5.1: build argument string manually
+            $psi.Arguments = ($argList | ForEach-Object { [char]34 + $_ + [char]34 }) -join ' '
+        }
 
         $process = [System.Diagnostics.Process]::Start($psi)
 


### PR DESCRIPTION
## Summary
- Build argument list using `.ArgumentList` on PowerShell 6+
- Manually join and quote arguments for PowerShell 5.1 fallback

## Testing
- `apt-get install -y powershell` *(fails: Unable to locate package)*
- `pwsh -NoLogo -NoProfile -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*
- `powershell -NoLogo -NoProfile -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689e1f609b188331b73157bb1c5f1585