### PR TITLE
Use full path for pull destination and normalize folder path

### DIFF
--- a/adb-file-manager.ps1
+++ b/adb-file-manager.ps1
@@ -904,6 +904,7 @@ function Select-PullItems {
     $destinationFolder = Show-FolderPicker "Select destination folder on PC"
     if (-not $destinationFolder) { Write-Host "🟡 Action cancelled." -ForegroundColor Yellow; return $null }
     if (-not (Test-Path -LiteralPath $destinationFolder)) { Write-ErrorMessage -Operation "Invalid path"; return $null }
+    $destinationFolder = [IO.Path]::GetFullPath($destinationFolder)
 
     return [PSCustomObject]@{
         State       = $State
@@ -975,7 +976,9 @@ function Execute-PullTransfer {
         $itemTotalSize = $ItemSizes[$item.FullPath]
 
         $adbCommand = { param($adbPath, $source, $dest, $serial) & $adbPath -s $serial pull $source $dest 2>&1 | Out-String }
-        $job = Start-PortableJob -ScriptBlock $adbCommand -ArgumentList @($script:AdbPath, $sourceItem, $Destination, $State.DeviceStatus.SerialNumber)
+        $job = Start-PortableJob -ScriptBlock $adbCommand -ArgumentList @(
+            $script:AdbPath, $sourceItem, $destPathOnPC, $State.DeviceStatus.SerialNumber
+        )
 
         $itemStartTime = Get-Date
         Write-Host ""


### PR DESCRIPTION
## Summary
- Ensure adb receives full destination path during pull operations
- Normalize user-selected destination folder to an absolute path

## Testing
- `pwsh -NoProfile -Command '[System.Management.Automation.Language.Parser]::ParseInput((Get-Content -Raw "./adb-file-manager.ps1"), [ref]$null, [ref]$null) | Out-Null; Write-Host "Parse succeeded"'`


------
https://chatgpt.com/codex/tasks/task_b_689e426c18f88331a863b87f0917c726