### PR TITLE
Fix script compatibility with older PowerShell versions

### DIFF
--- a/adb-file-manager.ps1
+++ b/adb-file-manager.ps1
@@ -379,15 +379,16 @@ function Update-DeviceStatus {
     $State = $startResult.State
     $result = Invoke-AdbCommand -State $State -Arguments @('devices') -NoSerial
     $State = $result.State
-    [string[]]$deviceLines = $result.Output -split '\r?\n' |
-        Where-Object { $_ -notmatch '^(List of devices attached|\* daemon)' -and $_.Trim() }
+    [string[]]$deviceLines = $result.Output -split "`n" |
+        ForEach-Object { $_.Trim() } |
+        Where-Object { $_ -and $_ -notlike 'List of devices attached*' -and $_ -notlike '* daemon*' }
 
     if ($deviceLines.Count -gt 0) {
         Write-Log "Detected devices: $($deviceLines -join ', ')" "DEBUG"
     }
 
     if ($deviceLines.Count -gt 0) {
-        $serials = $deviceLines | ForEach-Object { ($_ -split '\s+')[0].Trim() }
+        $serials = $deviceLines | ForEach-Object { $_.Split()[0].Trim() }
         $serialNumber = $State.DeviceStatus.SerialNumber
         if (-not $serialNumber -or -not ($serials -contains $serialNumber)) {
             if ($deviceLines.Count -gt 1) {
@@ -400,7 +401,7 @@ function Update-DeviceStatus {
                 if (-not [int]::TryParse($selection, [ref]$choice) -or $choice -lt 1 -or $choice -gt $deviceLines.Count) {
                     $choice = 1
                 }
-                $serialNumber = ($deviceLines[$choice - 1] -split '\s+')[0]
+                $serialNumber = ($deviceLines[$choice - 1].Split())[0]
             } else {
                 $serialNumber = $serials[0]
             }
@@ -947,7 +948,12 @@ function Get-AndroidDirectoryContents {
 
     # Use the canonical path for the 'ls' command to get just names; details come from stat.
     $lsArgs = @('shell','ls')
-    $lsArgs += ($State.Config.VerboseLists ? '-lA' : '-1A')
+    if ($State.Config.VerboseLists) {
+        $lsArgs += '-l'
+    } else {
+        $lsArgs += '-1'
+    }
+    $lsArgs += '-A'
     $lsArgs += "'$listPath'"
     $result = Invoke-AdbCommand -State $State -Arguments $lsArgs
     $State = $result.State


### PR DESCRIPTION
## Summary
- avoid using PowerShell 7 ternary operator when building ls arguments
- pass ls flags separately for better shell compatibility
- split adb `devices` output lines without regex quirks to keep full serial numbers

## Testing
- `pwsh -NoLogo -NoProfile -Command "$PSVersionTable.PSVersion.ToString()"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_b_689f2418b6f083318a9fd10238192672