### PR TITLE
Optimize directory metadata retrieval and add test coverage

### DIFF
--- a/tests/Get-AndroidDirectoryContents.Tests.ps1
+++ b/tests/Get-AndroidDirectoryContents.Tests.ps1
@@ -1,0 +1,20 @@
+Describe "Get-AndroidDirectoryContents" {
+    . "$PSScriptRoot/../adb-file-manager.ps1"
+
+    It "returns files, directories, and links" {
+        $state = @{ 
+            DirectoryCache = @{}
+            DirectoryCacheAliases = @{ '/data' = '/data' }
+            Features = @{ SupportsStatC = $true }
+            Config = @{ VerboseLists = $false }
+            MaxDirectoryCacheEntries = 100
+        }
+        Mock Invoke-AdbCommand {
+            param($State, $Arguments)
+            return [pscustomobject]@{ Success = $true; Output = "directory|0|/data/subdir`nregular file|12|/data/file.txt`nsymbolic link|0|/data/link"; State = $State }
+        } -ParameterFilter { $Arguments[0] -eq 'shell' -and $Arguments[1] -eq 'find' }
+        $res = Get-AndroidDirectoryContents -State $state -Path '/data'
+        $names = $res.Items | Sort-Object Name | ForEach-Object { $_.Name + ':' + $_.Type }
+        $names | Should -Be @('file.txt:File','link:Link','subdir:Directory')
+    }
+}


### PR DESCRIPTION
## Summary
- Use a single batched `find` command with `stat` or `ls` to collect directory entry metadata
- Track items by full path instead of relying on output order
- Add Pester test covering directories, files, and links in a subdirectory

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_b_689ffa55c4ac83319d9375e72b50c83d