### PR TITLE
Refine device status handling in UI

### DIFF
--- a/tests/Show-UIHeader.Tests.ps1
+++ b/tests/Show-UIHeader.Tests.ps1
@@ -1,0 +1,32 @@
+Describe "Show-UIHeader" {
+    BeforeAll {
+        . "$PSScriptRoot/../adb-file-manager.ps1"
+    }
+
+    It "renders a single status line when a device is connected" {
+        $state = @{
+            DeviceStatus = @{ IsConnected = $true; DeviceName = 'Test'; SerialNumber = 'ABC123' }
+            LastStatusUpdateTime = [DateTime]::MinValue
+        }
+
+        Mock Clear-Host {}
+        Mock Update-DeviceStatus {
+            param($State)
+            return [pscustomobject]@{
+                State = $state
+                Devices = @()
+                ConnectionChanged = $false
+                NeedsSelection = $false
+                StatusText = '🔌 Status: Test (ABC123)'
+            }
+        }
+
+        $writes = @()
+        Mock Write-Host { param($Object) $script:writes += $Object }
+
+        Show-UIHeader -State $state -SubTitle 'MAIN MENU' | Out-Null
+
+        $statusLines = $writes | Where-Object { $_ -match '🔌 Status:' }
+        $statusLines.Count | Should -Be 1
+    }
+}


### PR DESCRIPTION
## Summary
- show device list only when explicitly requested or multiple devices need selection
- return consolidated status text from Update-DeviceStatus
- ensure header displays a single centered status line and add test coverage

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a00162f74c8331897aa6412dbe068e