### PR TITLE
Improve directory loading feedback

### DIFF
--- a/adb-file-manager.ps1
+++ b/adb-file-manager.ps1
@@ -1773,9 +1773,8 @@ function Browse-AndroidFileSystem {
     }
 
     do {
-        $State = Show-UIHeader -State $State -Title "FILE BROWSER"
-        Write-Host "📁 Browsing: $currentPath" -ForegroundColor White -BackgroundColor DarkCyan
-        Write-Host ("─" * 62) -ForegroundColor Gray
+        Clear-Host
+        Write-Host "Loading directory..." -ForegroundColor Yellow
 
         # Cast the result to an array to prevent errors when a directory has only one item.
         $res = Get-AndroidDirectoryContents -State $State -Path $currentPath
@@ -1783,6 +1782,10 @@ function Browse-AndroidFileSystem {
 
         # Sort directories before files using a culture-invariant, case-insensitive comparer
         $items = Sort-BrowseItems $res.Items
+
+        $State = Show-UIHeader -State $State -Title "FILE BROWSER"
+        Write-Host "📁 Browsing: $currentPath" -ForegroundColor White -BackgroundColor DarkCyan
+        Write-Host ("─" * 62) -ForegroundColor Gray
 
         Write-Host " [ 0] .. (Go Up)" -ForegroundColor Yellow
         for ($i = 0; $i -lt $items.Count; $i++) {


### PR DESCRIPTION
## Summary
- Clear file browser screen and show a temporary 'Loading directory...' message before fetching directory contents

## Testing
- `pwsh -NoLogo -Command "Invoke-Pester"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_b_68a0039cb5608331adde90164368e161