### PR TITLE
Handle find errors when listing Android directories

### DIFF
--- a/tests/Get-AndroidDirectoryContents.Tests.ps1
+++ b/tests/Get-AndroidDirectoryContents.Tests.ps1
@@ -2,19 +2,39 @@ Describe "Get-AndroidDirectoryContents" {
     BeforeAll { . "$PSScriptRoot/../adb-file-manager.ps1" }
 
     It "returns files, directories, and links" {
-        $state = @{ 
+        $state = @{
             DirectoryCache = @{}
             DirectoryCacheAliases = @{ '/data' = '/data' }
-            Features = @{ SupportsStatC = $true }
+            Features = @{ SupportsStatC = $true; SupportsFind = $true }
             Config = @{ VerboseLists = $false }
             MaxDirectoryCacheEntries = 100
         }
         Mock Invoke-AdbCommand {
             param($State, $Arguments)
             return [pscustomobject]@{ Success = $true; Output = "directory|0|/data/subdir`nregular file|12|/data/file.txt`nsymbolic link|0|/data/link"; State = $State }
-        } -ParameterFilter { $Arguments[0] -eq 'shell' -and $Arguments[1] -eq 'find' }
+        } -ParameterFilter { $Arguments[0] -eq 'shell' -and $Arguments[1] -eq 'sh' }
         $res = Get-AndroidDirectoryContents -State $state -Path '/data'
         $names = $res.Items | Sort-Object Name | ForEach-Object { $_.Name + ':' + $_.Type }
         $names | Should -Be @('file.txt:File','link:Link','subdir:Directory')
+    }
+
+    It "keeps results even if find would fail" {
+        $state = @{
+            DirectoryCache = @{}
+            DirectoryCacheAliases = @{ '/data' = '/data' }
+            Features = @{ SupportsStatC = $true; SupportsFind = $true }
+            Config = @{ VerboseLists = $false }
+            MaxDirectoryCacheEntries = 100
+        }
+        Mock Invoke-AdbCommand {
+            param($State, $Arguments)
+            return [pscustomobject]@{ Success = $false; Output = "directory|0|/data/visible"; State = $State }
+        } -ParameterFilter { $Arguments[0] -eq 'shell' -and $Arguments[1] -eq 'find' }
+        Mock Invoke-AdbCommand {
+            param($State, $Arguments)
+            return [pscustomobject]@{ Success = $true; Output = "directory|0|/data/visible"; State = $State }
+        } -ParameterFilter { $Arguments[0] -eq 'shell' -and $Arguments[1] -eq 'sh' }
+        $res = Get-AndroidDirectoryContents -State $state -Path '/data'
+        ($res.Items | ForEach-Object { $_.Name }) | Should -Contain 'visible'
     }
 }

--- a/tests/Show-UIHeader.Tests.ps1
+++ b/tests/Show-UIHeader.Tests.ps1
@@ -21,7 +21,7 @@ Describe "Show-UIHeader" {
             }
         }
 
-        $writes = @()
+        $script:writes = @()
         Mock Write-Host { param($Object) $script:writes += $Object }
 
         Show-UIHeader -State $state -SubTitle 'MAIN MENU' | Out-Null


### PR DESCRIPTION
## Summary
- Detect `find` support on Android and wrap calls to preserve partial results when errors occur
- Fallback to `ls`/`stat` loops if `find` is unavailable
- Test directory listings with simulated unreadable entries and fix Pester variable scoping

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Script tests"`

------
https://chatgpt.com/codex/tasks/task_b_68a006c6fd288331a1b33418489fbc21