### PR TITLE
Simplify directory metadata retrieval

### DIFF
--- a/tests/Browse-AndroidFileSystem.Tests.ps1
+++ b/tests/Browse-AndroidFileSystem.Tests.ps1
@@ -114,9 +114,14 @@ Describe "Browse-AndroidFileSystem job error handling" {
         Mock Start-Sleep {}
         Mock Test-AndroidPath { $true }
         $realJob = (Get-Command Get-AndroidDirectoryContentsJob).ScriptBlock
+        $script:thrown = $false
         Mock Get-AndroidDirectoryContentsJob {
             $params = $PSBoundParameters
-            $params['Fetcher'] = { param($s,$p) throw 'invalid path' }
+            $params['Fetcher'] = {
+                param($s,$p)
+                if (-not $script:thrown) { $script:thrown = $true; throw 'invalid path' }
+                else { [pscustomobject]@{ State = $s; Items = @() } }
+            }
             & $realJob @params
         }
         $script:logged = @()

--- a/tests/Get-AndroidDirectoryContents.Tests.ps1
+++ b/tests/Get-AndroidDirectoryContents.Tests.ps1
@@ -1,82 +1,52 @@
 Describe "Get-AndroidDirectoryContents" {
     BeforeAll { . "$PSScriptRoot/../adb-file-manager.ps1" }
 
-    It "returns files, directories, and links" {
+    It "parses ls output and returns correct item types" {
         $state = @{
-            DirectoryCache = @{}
+            DirectoryCache = New-Object System.Collections.Specialized.OrderedDictionary ([StringComparer]::Ordinal)
             DirectoryCacheAliases = @{ '/data' = '/data' }
-            Features = @{ SupportsStatC = $true; SupportsFind = $true }
+            Features = @{}
             Config = @{ VerboseLists = $false }
             MaxDirectoryCacheEntries = 100
         }
+
+        $lsOut = @(
+            'drwxr-xr-x 2 root root 0 1700000000 subdir/',
+            '-rw-r--r-- 1 root root 12 1700000000 file.txt',
+            'lrwxrwxrwx 1 root root 4 1700000000 link -> /target'
+        ) -join "`n"
+
         Mock Invoke-AdbCommand {
-            param($State, $Arguments)
-            return [pscustomobject]@{ Success = $true; Output = "directory|0|/data/subdir`nregular file|12|/data/file.txt`nsymbolic link|0|/data/link"; State = $State }
-        } -ParameterFilter { $Arguments[-1] -like 'find*' }
+            param($State,$Arguments)
+            return [pscustomobject]@{ Success = $true; Output = $lsOut; State = $State }
+        } -Verifiable -ParameterFilter { $Arguments[1] -eq 'ls' }
+
         $res = Get-AndroidDirectoryContents -State $state -Path '/data'
         $names = $res.Items | Sort-Object Name | ForEach-Object { $_.Name + ':' + $_.Type }
         $names | Should -Be @('file.txt:File','link:Link','subdir:Directory')
+        Assert-MockCalled Invoke-AdbCommand -ParameterFilter { $Arguments[1] -eq 'ls' } -Times 1
     }
 
-    It "keeps results even if find would fail" {
+    It "returns cached results on subsequent calls" {
         $state = @{
-            DirectoryCache = @{}
+            DirectoryCache = New-Object System.Collections.Specialized.OrderedDictionary ([StringComparer]::Ordinal)
             DirectoryCacheAliases = @{ '/data' = '/data' }
-            Features = @{ SupportsStatC = $true; SupportsFind = $true }
+            Features = @{}
             Config = @{ VerboseLists = $false }
             MaxDirectoryCacheEntries = 100
         }
-        Mock Invoke-AdbCommand {
-            param($State, $Arguments)
-            return [pscustomobject]@{ Success = $false; Output = ""; State = $State }
-        } -ParameterFilter { $Arguments[-1] -like 'find*' }
-        Mock Invoke-AdbCommand {
-            param($State, $Arguments)
-            $out = @('total 0','drwxr-xr-x 2 root root 0 Jan 1 00:00 visible') -join "`n"
-            return [pscustomobject]@{ Success = $true; Output = $out; State = $State }
-        } -ParameterFilter { $Arguments[1] -eq 'ls' -and $Arguments[2] -eq '-al' }
-        $res = Get-AndroidDirectoryContents -State $state -Path '/data'
-        ($res.Items | ForEach-Object { $_.Name }) | Should -Contain 'visible'
-    }
 
-    It "falls back to ls when find fails and caches decision" {
-        $state = @{
-            DirectoryCache = @{}
-            DirectoryCacheAliases = @{ '/data' = '/data'; '/other' = '/other' }
-            Features = @{ SupportsStatC = $false; SupportsFind = $true }
-            Config = @{ VerboseLists = $false }
-            MaxDirectoryCacheEntries = 100
-        }
+        $lsOut = 'drwxr-xr-x 2 root root 0 1700000000 subdir/'
+
         Mock Invoke-AdbCommand {
-            param($State, $Arguments)
-            return [pscustomobject]@{ Success = $false; Output = ''; State = $State }
-        } -ParameterFilter { $Arguments[-1] -like 'find*' }
-        Mock Invoke-AdbCommand {
-            param($State, $Arguments)
-            $out = @(
-                'total 0',
-                'drwxr-xr-x 2 root root 0 Jan 1 00:00 subdir',
-                '-rw-r--r-- 1 root root 12 Jan 1 00:00 file.txt',
-                'd--------- 0 root root 0 Jan 1 00:00 restricted'
-            ) -join "`n"
-            return [pscustomobject]@{ Success = $true; Output = $out; State = $State }
-        } -ParameterFilter { $Arguments[1] -eq 'ls' -and $Arguments[2] -eq '-al' -and $Arguments[3] -eq "'/data'" }
-        Mock Invoke-AdbCommand {
-            param($State, $Arguments)
-            $out = @(
-                'total 0',
-                '-rw-r--r-- 1 root root 5 Jan 1 00:00 other.txt'
-            ) -join "`n"
-            return [pscustomobject]@{ Success = $true; Output = $out; State = $State }
-        } -ParameterFilter { $Arguments[1] -eq 'ls' -and $Arguments[2] -eq '-al' -and $Arguments[3] -eq "'/other'" }
+            param($State,$Arguments)
+            return [pscustomobject]@{ Success = $true; Output = $lsOut; State = $State }
+        } -Verifiable -ParameterFilter { $Arguments[1] -eq 'ls' }
 
         $res1 = Get-AndroidDirectoryContents -State $state -Path '/data'
-        $names1 = $res1.Items | Sort-Object Name | ForEach-Object { $_.Name + ':' + $_.Type }
-        $names1 | Should -Be @('file.txt:File','restricted:Directory','subdir:Directory')
-        $res1.State.Features.SupportsFind | Should -BeFalse
-
-        $res2 = Get-AndroidDirectoryContents -State $res1.State -Path '/other'
-        $res2.State.Features.SupportsFind | Should -BeFalse
-        Assert-MockCalled Invoke-AdbCommand -ParameterFilter { $Arguments[-1] -like 'find*' } -Times 1
+        $res2 = Get-AndroidDirectoryContents -State $res1.State -Path '/data'
+        Assert-MockCalled Invoke-AdbCommand -ParameterFilter { $Arguments[1] -eq 'ls' } -Times 1
+        ($res2.Items | ForEach-Object { $_.Name }) | Should -Contain 'subdir'
     }
 }
+


### PR DESCRIPTION
## Summary
- Replace multi-step directory probes with a single `ls -lAp --time-style=+%s` call
- Cache metadata by full path and remove secondary `ls -p -d` checks
- Expand tests to cover parsing and caching in one pass

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Output Detailed"`

------
https://chatgpt.com/codex/tasks/task_b_68a222992690833184cac4694c67aff4