### PR TITLE
Clear screen and show loading while validating paths

### DIFF
--- a/adb-file-manager.ps1
+++ b/adb-file-manager.ps1
@@ -1948,13 +1948,16 @@ function Browse-AndroidFileSystem {
                     $selectedIndex = [int]$choice - 1
                     $selectedItem = $items[$selectedIndex]
                     if ($selectedItem.Type -in "Directory", "Link") {
-                        if (Test-AndroidPath $selectedItem.FullPath) {
+                        Clear-Host
+                        $loadingMsg = "Loading..."
+                        Write-Host -NoNewline $loadingMsg -ForegroundColor Yellow
+                        $pathValid = Test-AndroidPath $selectedItem.FullPath
+                        Write-Host "`r" + (' ' * $loadingMsg.Length) + "`r" -NoNewline
+                        if ($pathValid) {
                             $currentPath = $selectedItem.FullPath
-                            Clear-Host
                         } else {
                             Write-ErrorMessage -Operation "Invalid path"
                             Start-Sleep -Seconds 1
-                            Clear-Host
                         }
                     } else {
                         Clear-Host


### PR DESCRIPTION
## Summary
- Clear host immediately after a directory is selected
- Display a short "Loading..." indicator while validating the selection

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Passthru"`


------
https://chatgpt.com/codex/tasks/task_b_68a24b3e9c088331a0e5ad39c6de5c26