### PR TITLE
refactor: remove ternary operator in Get-AndroidDirectoryContentsJob

### DIFF
--- a/adb-file-manager.ps1
+++ b/adb-file-manager.ps1
@@ -1760,7 +1760,8 @@ function Get-AndroidDirectoryContentsJob {
                 Write-Log "Invalid background job result; falling back to synchronous fetch." "ERROR"
                 $res = & $Fetcher $State $Path
                 if (-not $res) { $res = [pscustomobject]@{ State = $State; Items = $null } }
-                $res | Add-Member -NotePropertyName JobErrors -NotePropertyValue ($jobErrorText ? $jobErrorText : 'Invalid job result')
+                $jobNote = if ($jobErrorText) { $jobErrorText } else { 'Invalid job result' }
+                $res | Add-Member -NotePropertyName JobErrors -NotePropertyValue $jobNote
                 $res.State = $State
                 return $res
             }


### PR DESCRIPTION
## Summary
- replace ternary operator when adding JobErrors to result
- prepare for PowerShell 5.1 compatibility

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests"`
- `powershell -NoLogo -NoProfile -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a2d75ea5588331b74e31d1032c46f9