### PR TITLE
Add ls time-style feature detection and fallback

### DIFF
--- a/tests/Get-AndroidDirectoryContents.Tests.ps1
+++ b/tests/Get-AndroidDirectoryContents.Tests.ps1
@@ -5,7 +5,7 @@ Describe "Get-AndroidDirectoryContents" {
         $state = @{
             DirectoryCache = New-Object System.Collections.Specialized.OrderedDictionary ([StringComparer]::Ordinal)
             DirectoryCacheAliases = @{ '/data' = '/data' }
-            Features = @{}
+            Features = @{ SupportsLsTimeStyle = $true }
             Config = @{ VerboseLists = $false }
             MaxDirectoryCacheEntries = 100
         }
@@ -19,19 +19,19 @@ Describe "Get-AndroidDirectoryContents" {
         Mock Invoke-AdbCommand {
             param($State,$Arguments)
             return [pscustomobject]@{ Success = $true; Output = $lsOut; State = $State }
-        } -Verifiable -ParameterFilter { $Arguments[1] -eq 'ls' }
+        } -Verifiable -ParameterFilter { $Arguments[1] -eq 'ls' -and $Arguments -contains '--time-style=+%s' }
 
         $res = Get-AndroidDirectoryContents -State $state -Path '/data'
         $names = $res.Items | Sort-Object Name | ForEach-Object { $_.Name + ':' + $_.Type }
         $names | Should -Be @('file.txt:File','link:Link','subdir:Directory')
-        Assert-MockCalled Invoke-AdbCommand -ParameterFilter { $Arguments[1] -eq 'ls' } -Times 1
+        Assert-MockCalled Invoke-AdbCommand -ParameterFilter { $Arguments[1] -eq 'ls' -and $Arguments -contains '--time-style=+%s' } -Times 1
     }
 
     It "returns cached results on subsequent calls" {
         $state = @{
             DirectoryCache = New-Object System.Collections.Specialized.OrderedDictionary ([StringComparer]::Ordinal)
             DirectoryCacheAliases = @{ '/data' = '/data' }
-            Features = @{}
+            Features = @{ SupportsLsTimeStyle = $true }
             Config = @{ VerboseLists = $false }
             MaxDirectoryCacheEntries = 100
         }
@@ -41,12 +41,38 @@ Describe "Get-AndroidDirectoryContents" {
         Mock Invoke-AdbCommand {
             param($State,$Arguments)
             return [pscustomobject]@{ Success = $true; Output = $lsOut; State = $State }
-        } -Verifiable -ParameterFilter { $Arguments[1] -eq 'ls' }
+        } -Verifiable -ParameterFilter { $Arguments[1] -eq 'ls' -and $Arguments -contains '--time-style=+%s' }
 
         $res1 = Get-AndroidDirectoryContents -State $state -Path '/data'
         $res2 = Get-AndroidDirectoryContents -State $res1.State -Path '/data'
-        Assert-MockCalled Invoke-AdbCommand -ParameterFilter { $Arguments[1] -eq 'ls' } -Times 1
+        Assert-MockCalled Invoke-AdbCommand -ParameterFilter { $Arguments[1] -eq 'ls' -and $Arguments -contains '--time-style=+%s' } -Times 1
         ($res2.Items | ForEach-Object { $_.Name }) | Should -Contain 'subdir'
+    }
+
+    It "falls back when --time-style is unsupported" {
+        $state = @{
+            DirectoryCache = New-Object System.Collections.Specialized.OrderedDictionary ([StringComparer]::Ordinal)
+            DirectoryCacheAliases = @{ '/data' = '/data' }
+            Features = @{ SupportsLsTimeStyle = $false }
+            Config = @{ VerboseLists = $false }
+            MaxDirectoryCacheEntries = 100
+        }
+
+        $lsOut = @(
+            'drwxr-xr-x 2 root root 0 Jan 1 2024 subdir/',
+            '-rw-r--r-- 1 root root 12 Jan 1 2024 file.txt'
+        ) -join "`n"
+
+        Mock Invoke-AdbCommand {
+            param($State,$Arguments)
+            return [pscustomobject]@{ Success = $true; Output = $lsOut; State = $State }
+        } -Verifiable -ParameterFilter { $Arguments[1] -eq 'ls' -and -not ($Arguments -contains '--time-style=+%s') }
+
+        $res = Get-AndroidDirectoryContents -State $state -Path '/data'
+        $names = $res.Items | Sort-Object Name | ForEach-Object { $_.Name + ':' + $_.Type }
+        $names | Should -Be @('file.txt:File','subdir:Directory')
+        Assert-MockCalled Invoke-AdbCommand -ParameterFilter { $Arguments[1] -eq 'ls' -and -not ($Arguments -contains '--time-style=+%s') } -Times 1
+        ($res.Items | Where-Object Name -eq 'file.txt').Timestamp | Should -BeGreaterThan 0
     }
 }
 


### PR DESCRIPTION
## Summary
- detect device support for `ls --time-style=+%s`
- list directories with `--time-style` when supported, otherwise parse default `ls` timestamps
- cover both code paths with new tests

## Testing
- `pwsh -NoLogo -Command Invoke-Pester`

------
https://chatgpt.com/codex/tasks/task_b_68a2da6ccdb08331a26ca364277e4b4f