### PR TITLE
Ensure Show-UIHeader state initialization

### DIFF
--- a/adb-file-manager.ps1
+++ b/adb-file-manager.ps1
@@ -109,6 +109,7 @@ $script:State = @{
         EnableJsonLog                = $JsonLog.IsPresent
         WhatIf                       = $WhatIf.IsPresent
     }
+    UIHeaderShowedList = $false
 }
 
 # --- Core ADB and Logging Functions ---
@@ -741,7 +742,7 @@ function Show-UIHeader {
     Write-Host "║$blank║" -ForegroundColor Cyan
     Write-Host "╚$border╝" -ForegroundColor Cyan
 
-    $State.UIHeaderShowedList = $false
+    if (-not $State.ContainsKey('UIHeaderShowedList')) { $State.UIHeaderShowedList = $false } else { $State.UIHeaderShowedList = $false }
     $updateResult = Update-DeviceStatus -State $State
     $State = $updateResult.State
 


### PR DESCRIPTION
## Summary
- initialize `UIHeaderShowedList` in global state
- guard `Show-UIHeader` against missing `UIHeaderShowedList` key

## Testing
- `Invoke-Pester` *(fails: Failed to list directory '/data'. ls: unknown option --time-style)*

------
https://chatgpt.com/codex/tasks/task_b_68a2fdc84ec4833183f3d28f2c033b60