### PR TITLE
Fix Sort-BrowseItems culture parameter in V2 script

### DIFF
--- a/adb-file-manager-V2.ps1
+++ b/adb-file-manager-V2.ps1
@@ -262,8 +262,8 @@ function Sort-BrowseItems {
     param([array]$Items)
 
     $isDirectory = { param($i) $i.Type -eq 'Directory' -or ($i.Type -eq 'Link' -and $i.ResolvedType -eq 'Directory') }
-    $dirs  = $Items | Where-Object { & $isDirectory $_ } | Sort-Object -Property Name -Culture invariant -CaseSensitive:$false
-    $files = $Items | Where-Object { -not (& $isDirectory $_) } | Sort-Object -Property Name -Culture invariant -CaseSensitive:$false
+    $dirs  = $Items | Where-Object { & $isDirectory $_ } | Sort-Object -Property Name -Culture ([System.Globalization.CultureInfo]::InvariantCulture) -CaseSensitive:$false
+    $files = $Items | Where-Object { -not (& $isDirectory $_) } | Sort-Object -Property Name -Culture ([System.Globalization.CultureInfo]::InvariantCulture) -CaseSensitive:$false
     return @($dirs + $files)
 }
 


### PR DESCRIPTION
## Summary
- ensure Sort-BrowseItems uses a valid invariant culture for case-insensitive sorting

## Testing
- `pwsh -NoLogo -NoProfile -File /tmp/test.ps1`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests"` *(fails: Cannot find path '/workspace/ADB-FileManager/System.Windows.Forms.dll')*

------
https://chatgpt.com/codex/tasks/task_b_68a49db7f4a8833199d39a4fae78858e