### PR TITLE
feat: add file type emojis

### DIFF
--- a/tests/Browse-AndroidFileSystem.Tests.ps1
+++ b/tests/Browse-AndroidFileSystem.Tests.ps1
@@ -72,3 +72,23 @@ Describe "Sort-BrowseItems" {
         $sortedNames | Should -Be $expected
     }
 }
+
+Describe "Get-FileEmoji" {
+    BeforeAll { . "$PSScriptRoot/../adb-file-manager-V2.ps1" }
+
+    It "returns the correct emoji for known and unknown extensions" {
+        $cases = @{
+            'picture.png' = '🖼️'
+            'clip.mkv'    = '🎞️'
+            'track.flac'  = '🎵'
+            'manual.pdf'  = '📕'
+            'package.apk' = '🤖'
+            'archive.tar' = '📦'
+            'note.xyz'    = '📄'
+        }
+
+        foreach ($name in $cases.Keys) {
+            Get-FileEmoji -FileName $name | Should -Be $cases[$name]
+        }
+    }
+}

--- a/tests/Get-AndroidDirectoryContents.Tests.ps1
+++ b/tests/Get-AndroidDirectoryContents.Tests.ps1
@@ -27,5 +27,29 @@ Describe "Get-AndroidDirectoryContents" {
         Assert-MockCalled Invoke-AdbCommand -Times 1
         ($second | ForEach-Object { $_.Name }) | Should -Be @('subdir')
     }
+
+    It "assigns icons based on file extension" {
+        $lsOut = @(
+            "-rw-r--r-- 1 root root 0 1700000000 photo.jpg",
+            "-rw-r--r-- 1 root root 0 1700000000 movie.mp4",
+            "-rw-r--r-- 1 root root 0 1700000000 song.mp3",
+            "-rw-r--r-- 1 root root 0 1700000000 doc.pdf",
+            "-rw-r--r-- 1 root root 0 1700000000 app.apk",
+            "-rw-r--r-- 1 root root 0 1700000000 archive.zip",
+            "-rw-r--r-- 1 root root 0 1700000000 unknown.xyz"
+        ) -join "`n"
+
+        Mock Invoke-AdbCommand { [pscustomobject]@{ Success = $true; Output = $lsOut } } -Verifiable
+
+        $items = Get-AndroidDirectoryContents -Path '/data'
+        $lookup = $items | Group-Object -Property Name -AsHashTable -AsString
+        $lookup['photo.jpg'].Icon   | Should -Be '🖼️'
+        $lookup['movie.mp4'].Icon   | Should -Be '🎞️'
+        $lookup['song.mp3'].Icon    | Should -Be '🎵'
+        $lookup['doc.pdf'].Icon     | Should -Be '📕'
+        $lookup['app.apk'].Icon     | Should -Be '🤖'
+        $lookup['archive.zip'].Icon | Should -Be '📦'
+        $lookup['unknown.xyz'].Icon | Should -Be '📄'
+    }
 }
 


### PR DESCRIPTION
## Summary
- add `Get-FileEmoji` helper that returns icons for common file types
- display icons in directory listings using new `Icon` property
- test emoji mapping and icon assignment

## Testing
- `pwsh -NoLogo -Command "Invoke-Pester tests"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: package not found)*
- `curl -L https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/install-powershell.sh | bash -s stable` *(fails: unsupported Ubuntu version)*

------
https://chatgpt.com/codex/tasks/task_b_68a4a51c9a7c8331a1f923ac825c98da