### PR TITLE
Simplify browse item sorting by type only

### DIFF
--- a/adb-file-manager-V2.ps1
+++ b/adb-file-manager-V2.ps1
@@ -275,11 +275,12 @@ function Show-InlineProgress {
 # case-insensitively using invariant culture.
 function Sort-BrowseItems {
     param([array]$Items)
-
-    $isDirectory = { param($i) $i.Type -eq 'Directory' -or ($i.Type -eq 'Link' -and $i.ResolvedType -eq 'Directory') }
-    $dirs  = $Items | Where-Object { & $isDirectory $_ } | Sort-Object -Property Name -Culture ([System.Globalization.CultureInfo]::InvariantCulture) -CaseSensitive:$false
-    $files = $Items | Where-Object { -not (& $isDirectory $_) } | Sort-Object -Property Name -Culture ([System.Globalization.CultureInfo]::InvariantCulture) -CaseSensitive:$false
-    return @($dirs + $files)
+    # Only use the explicit Type field. Any future link-resolution should
+    # populate a dedicated property (e.g. TargetType) before reintroducing
+    # link-aware checks here.
+    $dirs  = @($Items | Where-Object { $_.Type -eq 'Directory' } | Sort-Object -Property Name -Culture ([System.Globalization.CultureInfo]::InvariantCulture) -CaseSensitive:$false)
+    $files = @($Items | Where-Object { $_.Type -ne 'Directory' } | Sort-Object -Property Name -Culture ([System.Globalization.CultureInfo]::InvariantCulture) -CaseSensitive:$false)
+    return $dirs + $files
 }
 
 

--- a/tests/Browse-AndroidFileSystem.Tests.ps1
+++ b/tests/Browse-AndroidFileSystem.Tests.ps1
@@ -1,5 +1,11 @@
 Describe "Sort-BrowseItems" {
-    BeforeAll { . "$PSScriptRoot/../adb-file-manager-V2.ps1" }
+    BeforeAll {
+        function Add-Type { param([Parameter(ValueFromRemainingArguments=$true)]$Args) }
+        $scriptPath = "$PSScriptRoot/../adb-file-manager-V2.ps1"
+        $raw = Get-Content $scriptPath -Raw
+        $raw = $raw -replace 'Start-ADBTool\s*$',''
+        Invoke-Expression $raw
+    }
 
     It "orders directories before other items and sorts names alphabetically" {
         $items = @(
@@ -37,15 +43,17 @@ Describe "Sort-BrowseItems" {
         $sortedNames | Should -Be @('Banana','Яблоко','ábaco','Éclair')
     }
 
-    It "treats symlinks to directories as directories" {
+    It "places symlinks after directories even if they resolve to directories" {
         $items = @(
             [pscustomobject]@{ Name = 'zeta'; Type = 'File' },
             [pscustomobject]@{ Name = 'alpha'; Type = 'Directory' },
-            [pscustomobject]@{ Name = 'link'; Type = 'Link'; ResolvedType = 'Directory' }
+            [pscustomobject]@{ Name = 'link'; Type = 'Link'; ResolvedType = 'Directory' },
+            [pscustomobject]@{ Name = 'gamma'; Type = 'Directory' },
+            [pscustomobject]@{ Name = 'beta'; Type = 'File' }
         )
 
         $sortedNames = (Sort-BrowseItems $items) | ForEach-Object { $_.Name }
-        $sortedNames | Should -Be @('alpha','link','zeta')
+        $sortedNames | Should -Be @('alpha','gamma','beta','link','zeta')
     }
 
     It "orders mixed-case and non-Latin names with directories first" {
@@ -74,7 +82,13 @@ Describe "Sort-BrowseItems" {
 }
 
 Describe "Get-FileEmoji" {
-    BeforeAll { . "$PSScriptRoot/../adb-file-manager-V2.ps1" }
+    BeforeAll {
+        function Add-Type { param([Parameter(ValueFromRemainingArguments=$true)]$Args) }
+        $scriptPath = "$PSScriptRoot/../adb-file-manager-V2.ps1"
+        $raw = Get-Content $scriptPath -Raw
+        $raw = $raw -replace 'Start-ADBTool\s*$',''
+        Invoke-Expression $raw
+    }
 
     It "returns the correct emoji for known and unknown extensions" {
         $cases = @{

--- a/tests/Get-AndroidDirectoryContents.Tests.ps1
+++ b/tests/Get-AndroidDirectoryContents.Tests.ps1
@@ -1,13 +1,19 @@
 Describe "Get-AndroidDirectoryContents" {
-    BeforeAll { . "$PSScriptRoot/../adb-file-manager-V2.ps1" }
+    BeforeAll {
+        function Add-Type { param([Parameter(ValueFromRemainingArguments=$true)]$Args) }
+        $scriptPath = "$PSScriptRoot/../adb-file-manager-V2.ps1"
+        $raw = Get-Content $scriptPath -Raw
+        $raw = $raw -replace 'Start-ADBTool\s*$',''
+        Invoke-Expression $raw
+    }
 
     BeforeEach { $script:DirectoryCache.Clear() }
 
     It "orders directories before files case-insensitively" {
         $lsOut = @(
             "-rw-r--r-- 1 root root 0 1700000000 zeta.txt",
-            "drwxr-xr-x 2 root root 0 1700000000 Alpha/",
-            "drwxr-xr-x 2 root root 0 1700000000 gamma/",
+            "drwxr-xr-x 2 root root 0 1700000000 Alpha",
+            "drwxr-xr-x 2 root root 0 1700000000 gamma",
             "-rw-r--r-- 1 root root 0 1700000000 beta.txt"
         ) -join "`n"
 
@@ -18,7 +24,7 @@ Describe "Get-AndroidDirectoryContents" {
     }
 
     It "caches the sorted results for subsequent calls" {
-        $lsOut = "drwxr-xr-x 2 root root 0 1700000000 subdir/"
+        $lsOut = "drwxr-xr-x 2 root root 0 1700000000 subdir"
         Mock Invoke-AdbCommand { [pscustomobject]@{ Success = $true; Output = $lsOut } } -Verifiable
 
         $first = Get-AndroidDirectoryContents -Path '/data'


### PR DESCRIPTION
## Summary
- remove ResolvedType logic from Sort-BrowseItems and rely solely on Type
- update browse tests to verify link handling and allow loading without GUI or main start
- adjust directory content tests for new sorting and test harness

## Testing
- `pwsh -NoLogo -Command "Import-Module Pester; Invoke-Pester tests/Browse-AndroidFileSystem.Tests.ps1"`
- `pwsh -NoLogo -Command "Import-Module Pester; Invoke-Pester tests/Get-AndroidDirectoryContents.Tests.ps1"`


------
https://chatgpt.com/codex/tasks/task_b_68a560bf93c883319cab99bb46bd9b43