### PR TITLE
Remove unused timestamp in Get-AndroidDirectoryContents

### DIFF
--- a/adb-file-manager-V2.ps1
+++ b/adb-file-manager-V2.ps1
@@ -406,13 +406,11 @@ function Get-AndroidDirectoryContents {
             $rest    = $Matches.rest
 
             $name      = $null
-            $timestamp = $null
 
             # Detect different timestamp formats from various ls implementations
-            if ($rest -match '^(?<ts>\d{10})\s+(?<name>.+?)(?:\s->\s.*)?$') {
+            if ($rest -match '^\d{10}\s+(?<name>.+?)(?:\s->\s.*)?$') {
                 # --time-style=+%s (epoch seconds)
-                $timestamp = [long]$Matches.ts
-                $name      = $Matches.name
+                $name = $Matches.name
             }
             elseif ($rest -match '^(?<date>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2})\s+(?<name>.+?)(?:\s->\s.*)?$') {
                 # ISO format (toybox/modern ls)


### PR DESCRIPTION
## Summary
- drop unused `$timestamp` variable in `Get-AndroidDirectoryContents`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Script tests/Get-AndroidDirectoryContents.Tests.ps1"`

------
https://chatgpt.com/codex/tasks/task_b_68a564f4b1d08331be3855e3802a2e06